### PR TITLE
Updated reimbursing template with full link to receipt + PR

### DIFF
--- a/treasurer/reimbursing/template.md
+++ b/treasurer/reimbursing/template.md
@@ -20,10 +20,10 @@
     - Description: Pub drinks
     - Purpose: Social
     - Cost ($): 50
-    - [Link to receipts](github link to receipt)
+    - [Link to receipts](https://github.com/UofTCoders/council/blob/master/treasurer/receipts/{{ ADD RECEIPT FILE HERE }})
 
 **Total**: 
     
-**[Link to Reimbursement Pull Request](https link to your PR)**
+**[Link to Reimbursement Pull Request](https://github.com/UofTCoders/council/pull/{{ ADD NUMBER HERE }})**
 
 ## Approval (seen in PR as well)


### PR DESCRIPTION
So that only a portion of the link needs to be changed rather than having to copy the link that (unmerged) doesn't exist.